### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "ruby"
+  run = "ruby"
+  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sonic
 Sonic the Hedgehog repl game. 
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/Sonic-1)](https://repl.it/github/UzayAnil/Sonic-1)
   
   
   a REPL game, based on sonic the hedgehog, showcasing animated cutscenes and sounds triggered by the users actions.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).